### PR TITLE
Added permission check to permission button in menu drawer

### DIFF
--- a/client/src/ts/global/navigation/MenuDrawer.tsx
+++ b/client/src/ts/global/navigation/MenuDrawer.tsx
@@ -275,17 +275,19 @@ const MenuDrawer: React.FunctionComponent<DrawerProps> = (props: DrawerProps) =>
                 <ListItemText className={classes.subListItem} primary="Kuratoren" />
               </ListItem>
             </NavLink>
-            <NavLink
-              exact
-              to="/berechtigungen"
-              className={classes.listItemNavText}
-              activeStyle={{ color: "rgb(246,137,31)", textDecoration: "none" }}
-              onClick={handleNavLinkClick(pathname)}
-            >
-              <ListItem button onClick={props.drawer(false)}>
-                <ListItemText className={classes.subListItem} primary="Berechtigungen" />
-              </ListItem>
-            </NavLink>
+            {auth.permissions.length > 0 ? (
+              <NavLink
+                exact
+                to="/berechtigungen"
+                className={classes.listItemNavText}
+                activeStyle={{ color: "rgb(246,137,31)", textDecoration: "none" }}
+                onClick={handleNavLinkClick(pathname)}
+              >
+                <ListItem button onClick={props.drawer(false)}>
+                  <ListItemText className={classes.subListItem} primary="Berechtigungen" />
+                </ListItem>
+              </NavLink>
+            ) : null}
           </List>
         </Collapse>
         <NavLink


### PR DESCRIPTION
Added check for empty permission array of the logged in user.

How to test:
1. Log in with a user who has no permissions
--> Opening the member tab of the menu drawer should not contain the permission tab
2. Log in with a user who has some permissions
--> Opening the member tab of the menu drawer should contain the permission tab