### PR TITLE
Added missing type in authTypes

### DIFF
--- a/server/src/global/auth/authTypes.ts
+++ b/server/src/global/auth/authTypes.ts
@@ -20,3 +20,10 @@ export type UserDataQueryResult = {
   name: string;
   permissions: string;
 };
+
+/**
+ * Type of query results of the permission retrieval
+ */
+export type DirectorPermissionsQueryResult = {
+  permissions: string;
+};


### PR DESCRIPTION
How to test:
1. Check if the member w.luft (8167) has permissions in the database
2. Make following request in an api client of your choice:
GET _https://localhost:3030/users/8167/permissions_
--> This should return the list of permissions of w.luft
3. Make following request in an api client of your choice:
GET _https://localhost:3030/users/9999/permissions_
--> This should return the message 'Member with id "9999" does not exist'